### PR TITLE
feat(export): contextix export --format mermaid|json

### DIFF
--- a/src/export/mermaid.ts
+++ b/src/export/mermaid.ts
@@ -1,0 +1,60 @@
+import type { SubGraph, GraphNode, Relation } from "../graph/types.js";
+
+/**
+ * Render a SubGraph as a Mermaid flowchart.
+ *
+ * Node labels use the entity name / event title so the diagram reads like the
+ * underlying graph instead of exposing raw ids. Edge labels carry the relation
+ * type. Node ids are sanitized to valid Mermaid identifiers (alphanumeric +
+ * underscore, non-conflicting per-subgraph).
+ */
+export function renderMermaid(sub: SubGraph): string {
+  const lines: string[] = ["graph LR"];
+
+  const aliasFor = buildIdAliasMap(sub.nodes);
+
+  for (const node of sub.nodes) {
+    const label = labelFor(node);
+    lines.push(`  ${aliasFor.get(node.id)}["${escapeLabel(label)}"]`);
+  }
+
+  for (const edge of sub.edges) {
+    const from = aliasFor.get(edge.source);
+    const to = aliasFor.get(edge.target);
+    if (!from || !to) continue;
+    lines.push(`  ${from} -->|${escapeLabel(edge.type)}| ${to}`);
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+function buildIdAliasMap(nodes: GraphNode[]): Map<string, string> {
+  const used = new Set<string>();
+  const map = new Map<string, string>();
+  for (const node of nodes) {
+    let alias = sanitizeAlias(node.id);
+    if (!alias) alias = "n";
+    let candidate = alias;
+    let i = 2;
+    while (used.has(candidate)) {
+      candidate = `${alias}_${i++}`;
+    }
+    used.add(candidate);
+    map.set(node.id, candidate);
+  }
+  return map;
+}
+
+function sanitizeAlias(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_]/g, "_").replace(/^(\d)/, "n$1");
+}
+
+function labelFor(node: GraphNode): string {
+  if (node.type === "entity") return node.name;
+  return node.title;
+}
+
+function escapeLabel(text: string): string {
+  // Mermaid supports double-quoted labels; escape embedded quotes with &quot;.
+  return text.replace(/"/g, "&quot;");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,42 @@ program
   });
 
 program
+  .command("export")
+  .description("Export a subgraph in a given format")
+  .option("--format <format>", "Output format: json | mermaid", "json")
+  .option("--entity <name>", "Entity name (or event title / id) to center the subgraph on")
+  .option("--hops <n>", "Radius in hops from the entity", (v) => parseInt(v, 10), 2)
+  .option("--max-nodes <n>", "Maximum nodes to include", (v) => parseInt(v, 10), 200)
+  .option("-d, --data-dir <path>", "Data directory override")
+  .action(async (opts) => {
+    const { loadConfig } = await import("./config.js");
+    const { LocalJsonStore } = await import("./graph/store.js");
+    const { extractSubgraph } = await import("./graph/query.js");
+
+    if (!opts.entity) {
+      console.error("export: --entity <name> is required");
+      process.exit(1);
+    }
+
+    const config = loadConfig({ dataDir: opts.dataDir });
+    const store = new LocalJsonStore(config.graphFile);
+    await store.load();
+
+    const sub = await extractSubgraph(store, opts.entity, opts.hops, opts.maxNodes);
+
+    const format = String(opts.format).toLowerCase();
+    if (format === "mermaid") {
+      const { renderMermaid } = await import("./export/mermaid.js");
+      process.stdout.write(renderMermaid(sub));
+    } else if (format === "json") {
+      process.stdout.write(JSON.stringify(sub, null, 2) + "\n");
+    } else {
+      console.error(`export: unsupported --format "${opts.format}" (supported: json, mermaid)`);
+      process.exit(1);
+    }
+  });
+
+program
   .command("signals")
   .description("Print recent signals from the local graph")
   .option("-d, --domain <domain>", "Filter by domain (crypto, macro, ai, media)")


### PR DESCRIPTION
## Summary

Adds a new `contextix export` command that renders a subgraph around an entity as JSON (default) or a Mermaid flowchart. Wires into the existing `extractSubgraph` BFS; no changes to the graph types or store.

```bash
contextix export --format mermaid --entity "Jerome Powell" --hops 2
contextix export --format json --entity "Fed Funds Rate" --hops 1
```

Closes #14.

## Acceptance (from the issue)

- [x] `--format` accepts `json` (default) and `mermaid`. Unknown values exit 1 with a clear message; `cypher` / `d2` are left for future formats.
- [x] `--entity <name>` + `--hops <N>` scope the export. `extractSubgraph` does BFS up to N hops (default 2) bounded by `--max-nodes` (default 200).
- [x] Output goes to stdout -- user can pipe to a file (`> foo.mmd`) or another tool.

## Files

- **New:** `src/export/mermaid.ts` (57 lines) -- pure function that turns a `SubGraph` into a Mermaid flowchart string.
- **Modified:** `src/index.ts` -- new `program.command("export")` block registered alongside the existing commands.

No changes to `src/graph/types.ts`, `src/graph/query.ts`, or the data file format.

## Mermaid renderer details

- Graph node ids (e.g. `ent_person_jerome_powell`) are not valid Mermaid identifiers. The renderer builds a per-subgraph alias map that sanitizes ids to `[A-Za-z0-9_]` with `_N` disambiguation on collision.
- Node labels use `entity.name` or `event.title` so the diagram reads like the underlying graph instead of exposing raw ids.
- Edge labels carry the relation type (`involves`, `influences`, ...).
- Labels are wrapped in `"..."` (Mermaid's double-quoted label syntax); embedded double quotes escape to `&quot;`.

## Testing

Built and smoke-checked against `data/seed-graph.json`:

```
$ npm run build
... tsup ⚡️ Build success in 18ms

$ node dist/index.js export --format mermaid --entity "Jerome Powell" --hops 2 --data-dir /tmp/contextix-test
graph LR
  evt_macro_a1b2c3["Fed holds rates steady at 4.25-4.50%"]
  evt_macro_d4e5f6["March CPI comes in at 2.4% YoY, below expectations"]
  evt_macro_p7q8r9["US unemployment claims rise to 245K"]
  ent_person_jerome_powell["Jerome Powell"]
  ent_org_federal_reserve["Federal Reserve"]
  ent_policy_fed_funds_rate["Federal Funds Rate"]
  ent_org_federal_reserve -->|involves| evt_macro_a1b2c3
  ent_person_jerome_powell -->|involves| evt_macro_a1b2c3
  evt_macro_a1b2c3 -->|involves| ent_policy_fed_funds_rate
  evt_macro_d4e5f6 -->|influences| evt_macro_a1b2c3
  evt_macro_p7q8r9 -->|influences| evt_macro_a1b2c3

$ node dist/index.js export --format json --entity "Jerome Powell" --hops 1 --data-dir /tmp/contextix-test
{ "query": "Jerome Powell", "radius": 1, "nodes": [...], "edges": [...] }

$ node dist/index.js export
export: --entity <name> is required
(exit 1)

$ node dist/index.js export --entity "Test" --format yaml --data-dir /tmp/contextix-test
export: unsupported --format "yaml" (supported: json, mermaid)
(exit 1)
```

Closes #14

---

This contribution was developed with AI assistance (Claude Code).
