### PR TITLE
feat: add graph-stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ contextix signals --domain crypto -t 7d
 contextix why "<event>"                 # Causal chain (BFS backward)
 contextix connect "<a>" "<b>"           # Shortest path between entities
 contextix entities --search "fed"       # Entity lookup
+contextix graph-stats                   # Local graph counts and orphan nodes
 ```
 
 Output is human-readable by default. `--json` for piping.

--- a/src/graph/stats.ts
+++ b/src/graph/stats.ts
@@ -1,0 +1,50 @@
+import type { SignalGraph } from "./types.js";
+
+export interface GraphStats {
+  events: number;
+  entities: number;
+  activeRelations: number;
+  domains: string[];
+  orphanNodes: number;
+}
+
+export function getGraphStats(graph: SignalGraph): GraphStats {
+  const nodeIds = new Set(graph.nodes.map((node) => node.id));
+  const connectedNodeIds = new Set<string>();
+  const activeRelations = graph.edges.filter((edge) => {
+    const valid = nodeIds.has(edge.source) && nodeIds.has(edge.target);
+    if (valid) {
+      connectedNodeIds.add(edge.source);
+      connectedNodeIds.add(edge.target);
+    }
+    return valid;
+  });
+
+  const nodeDomains = graph.nodes
+    .map((node) => node.domain)
+    .filter((domain): domain is string => Boolean(domain));
+  const domains = [...new Set([...nodeDomains, ...graph.meta.domains])].sort();
+
+  return {
+    events: graph.nodes.filter((node) => node.type === "event").length,
+    entities: graph.nodes.filter((node) => node.type === "entity").length,
+    activeRelations: activeRelations.length,
+    domains,
+    orphanNodes: graph.nodes.filter((node) => !connectedNodeIds.has(node.id)).length,
+  };
+}
+
+export function formatGraphStats(stats: GraphStats): string {
+  const labelWidth = 17;
+  const countWidth = 6;
+  const countRow = (label: string, count: number) =>
+    `${label.padEnd(labelWidth)} ${String(count).padStart(countWidth)}`;
+
+  return [
+    countRow("events:", stats.events),
+    countRow("entities:", stats.entities),
+    countRow("active relations:", stats.activeRelations),
+    `${"domains:".padEnd(labelWidth)} ${stats.domains.join(", ") || "(none)"}`,
+    countRow("orphan nodes:", stats.orphanNodes),
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,28 @@ program
   });
 
 program
+  .command("graph-stats")
+  .description("Print counts from the local graph")
+  .option("--data-dir <path>", "Data directory override")
+  .option("--json", "Output JSON instead of text")
+  .action(async (opts) => {
+    const { loadConfig } = await import("./config.js");
+    const { LocalJsonStore } = await import("./graph/store.js");
+    const { formatGraphStats, getGraphStats } = await import("./graph/stats.js");
+
+    const config = loadConfig({ dataDir: opts.dataDir });
+    const store = new LocalJsonStore(config.graphFile);
+    const graph = await store.load();
+    const stats = getGraphStats(graph);
+
+    if (opts.json) {
+      console.log(JSON.stringify(stats, null, 2));
+    } else {
+      console.log(formatGraphStats(stats));
+    }
+  });
+
+program
   .command("parse")
   .description("Parse text from stdin into graph fragment JSON on stdout")
   .action(async () => {


### PR DESCRIPTION
## Summary
- add a read-only graph-stats command that loads the local JSON graph and reports event, entity, active relation, domain, and orphan-node counts
- support --json output for scripting and --data-dir for non-default graph locations
- document the command in the CLI query section

## Tests
- npm run typecheck
- npm run build
- node dist/index.js graph-stats --data-dir /private/tmp/contextix-graph-stats-smoke
- node dist/index.js graph-stats --data-dir /private/tmp/contextix-graph-stats-smoke --json

Closes #4